### PR TITLE
Change Rails dependency restrictions to allow updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     trix-gem (0.11.2)
-      rails (> 7.0, < 7.1)
+      rails (> 7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/trix-gem.gemspec
+++ b/trix-gem.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rails", ["> 7.0", "< 7.1"]
+  spec.add_runtime_dependency "rails", "> 7.0"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
I'm working on [this task](https://app.asana.com/0/1200012343654579/1209169225385500) and need to update this gem. @raglan-road , you changed the gemspec not to allow Rails' versions greater or equal to 7.1. Is there anything I should know?